### PR TITLE
Adapted basic form elements to V5

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -7,7 +7,6 @@ return [
         'ignoredViewHelpers'        => [
             'button',
             'checkbox',
-            'file',
             'hidden',
             'multi_checkbox',
             'radio',
@@ -16,6 +15,7 @@ return [
             'static',
             'add_on',
         ],
+        'defaultRowSpacingClass'    => 'mb-3',
         'validTagAttributes'        => [],
         'validTagAttributePrefixes' => [],
         'type_map'                  => [],
@@ -85,7 +85,6 @@ return [
             'formsubmit'          => \TwbsHelper\Form\View\Helper\FormButton::class,
             'formcheckbox'        => \TwbsHelper\Form\View\Helper\FormCheckbox::class,
             'formelement_errors'  => \TwbsHelper\Form\View\Helper\FormElementErrors::class,
-            'formfile'            => \TwbsHelper\Form\View\Helper\FormFile::class,
             'formmulticheckbox'   => \TwbsHelper\Form\View\Helper\FormMultiCheckbox::class,
             'formradio'           => \TwbsHelper\Form\View\Helper\FormRadio::class,
             'formrange'           => \TwbsHelper\Form\View\Helper\FormRange::class,

--- a/src/TwbsHelper/Form/View/Helper/FormCheckbox.php
+++ b/src/TwbsHelper/Form/View/Helper/FormCheckbox.php
@@ -17,8 +17,7 @@ class FormCheckbox extends \Laminas\Form\View\Helper\FormCheckbox
         if (!$oElement->getOption('disable_twbs')) {
             $this->setClassesToElement(
                 $oElement,
-                [$oElement->getOption('custom') ? 'custom-control-input' : 'form-check-input'],
-                ['form-control']
+                ['form-check-input']
             );
         }
         return parent::render($oElement);

--- a/src/TwbsHelper/Form/View/Helper/FormFile.php
+++ b/src/TwbsHelper/Form/View/Helper/FormFile.php
@@ -14,31 +14,6 @@ class FormFile extends \Laminas\Form\View\Helper\FormFile
      */
     public function render(\Laminas\Form\ElementInterface $oElement): string
     {
-        $bCustom = $oElement->getOption('custom');
-
-        $sElementContent =  parent::render($this->setClassesToElement(
-            $oElement,
-            [$bCustom ? 'custom-file-input' : 'form-control-file'],
-            ['form-control']
-        ));
-
-        if ($bCustom) {
-            if ($sLabel = $oElement->getOption('custom_label')) {
-                $sLabelTmp = $oElement->getLabel();
-                $oElement->setLabel($sLabel);
-                $sLabel = $this->getView()->plugin('form_label')->__invoke($oElement);
-                $oElement->setLabel($sLabelTmp ?? '');
-                if ($sLabel) {
-                    $sElementContent .= PHP_EOL . $sLabel;
-                }
-            }
-
-            $sElementContent = $this->htmlElement(
-                'div',
-                ['class' => 'custom-file'],
-                $sElementContent
-            );
-        }
-        return $sElementContent;
+        return parent::render($oElement);
     }
 }

--- a/src/TwbsHelper/Form/View/Helper/FormLabel.php
+++ b/src/TwbsHelper/Form/View/Helper/FormLabel.php
@@ -40,7 +40,11 @@ class FormLabel extends \Laminas\Form\View\Helper\FormLabel
         }
 
         if ($oElement instanceof \Laminas\Form\LabelAwareInterface) {
+
             $aLabelAttributes = $oElement->getLabelAttributes();
+            if (!$oElement instanceof \Laminas\Form\Element\Checkbox) {
+                $aLabelAttributes = array_merge(['class' => 'form-label'], $aLabelAttributes);
+            }
 
             $oElement->setLabelAttributes($aLabelAttributes = $this->setClassesToAttributes(
                 $aLabelAttributes,
@@ -133,15 +137,7 @@ class FormLabel extends \Laminas\Form\View\Helper\FormLabel
         switch ($oElement->getAttribute('type')) {
             case 'checkbox':
             case 'radio':
-                $aLabelClasses[] = $oElement->getOption('custom')
-                    ? 'custom-control-label'
-                    : 'form-check-label';
-                break;
-
-            case 'file':
-                if ($oElement->getOption('custom')) {
-                    $aLabelClasses[] = 'custom-file-label';
-                }
+                $aLabelClasses[] = 'form-check-label';
                 break;
 
             default:

--- a/src/TwbsHelper/Form/View/Helper/FormRow.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRow.php
@@ -105,7 +105,7 @@ class FormRow extends \Laminas\Form\View\Helper\FormRow
      */
     public function renderFormRow(\Laminas\Form\ElementInterface $oElement, $sElementContent): string
     {
-        $aRowClasses = ['mb-3'];
+        $aRowClasses = [$this->options->getDefaultRowSpacingClass()];
 
         if ($oElement->getMessages()) {
             $aRowClasses[]  = 'has-error';

--- a/src/TwbsHelper/Form/View/Helper/FormRow.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRow.php
@@ -105,7 +105,7 @@ class FormRow extends \Laminas\Form\View\Helper\FormRow
      */
     public function renderFormRow(\Laminas\Form\ElementInterface $oElement, $sElementContent): string
     {
-        $aRowClasses = ['form-group'];
+        $aRowClasses = ['mb-3'];
 
         if ($oElement->getMessages()) {
             $aRowClasses[]  = 'has-error';

--- a/src/TwbsHelper/Form/View/Helper/FormSelect.php
+++ b/src/TwbsHelper/Form/View/Helper/FormSelect.php
@@ -14,14 +14,13 @@ class FormSelect extends \Laminas\Form\View\Helper\FormSelect
      */
     public function render(\Laminas\Form\ElementInterface $oElement): string
     {
-        if ($bIsCustom = $oElement->getOption('custom')) {
-            $this->setClassesToElement($oElement, ['custom-select']);
-        }
+        $this->setClassesToElement($oElement, ['form-select'], ['form-control']);
+
 
         if ($sSizeOption = $oElement->getOption('size')) {
             $this->setClassesToElement($oElement, [$this->getSizeClass(
                 $sSizeOption,
-                $bIsCustom ? 'custom-select' : 'form-control'
+                'form-select'
             )]);
         }
 

--- a/src/TwbsHelper/Form/View/Helper/MultiCheckboxTrait.php
+++ b/src/TwbsHelper/Form/View/Helper/MultiCheckboxTrait.php
@@ -22,14 +22,13 @@ trait MultiCheckboxTrait
         }
 
         $this->prepareElement($oElement);
-        $bIsCustom = $oElement->getOption('custom');
 
         $sOriginalSeparator = $this->getSeparator();
         $sTmpSeparator = '[SEPARATOR]';
         $this->setSeparator($sTmpSeparator);
 
         $aOriginalLabelAttributes = $this->labelAttributes;
-        $this->labelAttributes = ['class' => $bIsCustom ? 'custom-control-label' : 'form-check-label'];
+        $this->labelAttributes = ['class' => 'form-check-label'];
 
         $sTmpContent = parent::render($oElement);
 
@@ -62,11 +61,9 @@ trait MultiCheckboxTrait
             return;
         }
 
-        $bIsCustom = $oElement->getOption('custom');
-
         $this->setClassesToElement(
             $oElement,
-            [$bIsCustom ? 'custom-control-input' : 'form-check-input'],
+            ['form-check-input'],
             ['form-control']
         );
 
@@ -103,11 +100,10 @@ trait MultiCheckboxTrait
             return $sOptionContent;
         }
 
-        $bIsCustom = $oElement->getOption('custom');
-        $aGroupClasses = $bIsCustom ? ['custom-control', 'custom-radio'] : ['form-check'];
+        $aGroupClasses = ['form-check'];
 
         if ($oElement->getOption('layout') === \TwbsHelper\Form\View\Helper\Form::LAYOUT_INLINE) {
-            $aGroupClasses[] = $bIsCustom ? 'custom-control-inline' : 'form-check-inline';
+            $aGroupClasses[] = 'form-check-inline';
         }
         return $this->htmlElement(
             'div',

--- a/src/TwbsHelper/Options/ModuleOptions.php
+++ b/src/TwbsHelper/Options/ModuleOptions.php
@@ -28,6 +28,34 @@ class ModuleOptions extends AbstractOptions
     // @var array
     protected $typeMap;
 
+    // @var string
+    protected $defaultRowSpacingClass;
+
+    /**
+     * getDefaultRowSpacingClass
+     *
+     * @access public
+     * @return array
+     */
+    public function getDefaultRowSpacingClass()
+    {
+        return $this->defaultRowSpacingClass;
+    }
+
+    /**
+     * setDefaultRowSpacingClass
+     *
+     * @param  strgin $sDefaultRowSpacingClass
+     * @access public
+     * @return \TwbsHelper\Options\ModuleOptions
+     */
+    public function setDefaultRowSpacingClass(string $sDefaultRowSpacingClass)
+    {
+        $this->defaultRowSpacingClass = $sDefaultRowSpacingClass;
+        
+        return $this;
+    }
+
 
     /**
      * getIgnoredViewHelpers


### PR DESCRIPTION
1. Class 'form-group' replaced by 'mb-3'
2. Class 'form-label' added to LABEL tag
3. Checkbox element adapted to V5
4. Select element adated to V5
5. Radio element adapted to V5
6. File element adapted to V5
7. Removed 'custom' option support for elements - it's not supported by V5 anymore