### PR TITLE
Fix label position for radio boxes in 4.x series

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 4.x
   pull_request:
     paths-ignore:
       - "**.md"

--- a/src/TwbsHelper/Form/View/Helper/FormRow.php
+++ b/src/TwbsHelper/Form/View/Helper/FormRow.php
@@ -85,8 +85,6 @@ class FormRow extends \Laminas\Form\View\Helper\FormRow
         switch (true) {
                 // Form group disabled
             case $element->getOption('form_group') === false:
-                // Radio elements
-            case $elementType === 'radio':
                 // All "button" elements in inline form
             case in_array($elementType, ['submit', 'button', 'reset'], true)
                 && $layout === \TwbsHelper\Form\View\Helper\Form::LAYOUT_INLINE:
@@ -305,9 +303,12 @@ class FormRow extends \Laminas\Form\View\Helper\FormRow
             }
         }
 
+        if ($element instanceof \Laminas\Form\Element\MultiCheckbox) {
+            return self::LABEL_PREPEND;
+        }
+
         switch ($element->getAttribute('type')) {
             case 'checkbox':
-            case 'radio':
                 return self::LABEL_APPEND;
             case 'file':
                 if ($element->getOption('custom')) {

--- a/tests/TestSuite/Documentation/Tests/Components/Forms/CustomForms.php
+++ b/tests/TestSuite/Documentation/Tests/Components/Forms/CustomForms.php
@@ -40,6 +40,7 @@ return [
                             'name' => 'customRadio',
                             'type' => 'radio',
                             'options' => [
+                                'form_group' => false,
                                 'custom' => true,
                                 'value_options' => [
                                     [
@@ -68,6 +69,7 @@ return [
                             'type' => 'radio',
                             'options' => [
                                 'layout' => \TwbsHelper\Form\View\Helper\Form::LAYOUT_INLINE,
+                                'form_group' => false,
                                 'custom' => true,
                                 'value_options' => [
                                     [
@@ -110,6 +112,7 @@ return [
                             'name' => 'radioDisabled',
                             'type' => 'radio',
                             'options' => [
+                                'form_group' => false,
                                 'custom' => true,
                                 'value_options' => [
                                     [

--- a/tests/TestSuite/Documentation/Tests/Components/Forms/Layout/FormGrid/HorizontalForm.php
+++ b/tests/TestSuite/Documentation/Tests/Components/Forms/Layout/FormGrid/HorizontalForm.php
@@ -53,7 +53,6 @@ return [
                                     'type' => 'radio',
                                     'name' => 'gridRadios',
                                     'options' => [
-                                        'column' => 'sm-10',
                                         'value_options' => [
                                             [
                                                 'label' => 'First radio',

--- a/tests/TestSuite/Documentation/__snapshots__/Components/Forms/Layout/Form_grid/Horizontal_form__1.html
+++ b/tests/TestSuite/Documentation/__snapshots__/Components/Forms/Layout/Form_grid/Horizontal_form__1.html
@@ -16,17 +16,19 @@
         <div class="row">
             <legend class="col-form-label col-sm-2 pt-0">Radios</legend>
             <div class="col-sm-10">
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios1" value="option1">
-                    <label class="form-check-label" for="gridRadios1">First radio</label>
-                </div>
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios2" value="option2">
-                    <label class="form-check-label" for="gridRadios2">Second radio</label>
-                </div>
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios3" value="option3" disabled>
-                    <label class="form-check-label" for="gridRadios3">Third disabled radio</label>
+                <div class="form-group">
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios1" value="option1">
+                        <label class="form-check-label" for="gridRadios1">First radio</label>
+                    </div>
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios2" value="option2">
+                        <label class="form-check-label" for="gridRadios2">Second radio</label>
+                    </div>
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios3" value="option3" disabled>
+                        <label class="form-check-label" for="gridRadios3">Third disabled radio</label>
+                    </div>
                 </div>
             </div>
         </div>

--- a/tests/TestSuite/Documentation/__snapshots__/Components/Forms/Layout/Inline_forms/Horizontal_form__1.html
+++ b/tests/TestSuite/Documentation/__snapshots__/Components/Forms/Layout/Inline_forms/Horizontal_form__1.html
@@ -16,17 +16,19 @@
         <div class="row">
             <legend class="col-form-label col-sm-2 pt-0">Radios</legend>
             <div class="col-sm-10">
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios1" value="option1">
-                    <label class="form-check-label" for="gridRadios1">First radio</label>
-                </div>
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios2" value="option2">
-                    <label class="form-check-label" for="gridRadios2">Second radio</label>
-                </div>
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios3" value="option3" disabled>
-                    <label class="form-check-label" for="gridRadios3">Third disabled radio</label>
+                <div class="form-group">
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios1" value="option1">
+                        <label class="form-check-label" for="gridRadios1">First radio</label>
+                    </div>
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios2" value="option2">
+                        <label class="form-check-label" for="gridRadios2">Second radio</label>
+                    </div>
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios3" value="option3" disabled>
+                        <label class="form-check-label" for="gridRadios3">Third disabled radio</label>
+                    </div>
                 </div>
             </div>
         </div>

--- a/website/docs/usage/components/forms.mdx
+++ b/website/docs/usage/components/forms.mdx
@@ -1092,17 +1092,19 @@ echo $this->form(
         <div class="row">
             <legend class="col-form-label col-sm-2 pt-0">Radios</legend>
             <div class="col-sm-10">
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios1" value="option1"></input>
-                    <label class="form-check-label" for="gridRadios1">First radio</label>
-                </div>
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios2" value="option2"></input>
-                    <label class="form-check-label" for="gridRadios2">Second radio</label>
-                </div>
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios3" value="option3" disabled="disabled"></input>
-                    <label class="form-check-label" for="gridRadios3">Third disabled radio</label>
+                <div class="form-group">
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios1" value="option1"></input>
+                        <label class="form-check-label" for="gridRadios1">First radio</label>
+                    </div>
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios2" value="option2"></input>
+                        <label class="form-check-label" for="gridRadios2">Second radio</label>
+                    </div>
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios3" value="option3" disabled="disabled"></input>
+                        <label class="form-check-label" for="gridRadios3">Third disabled radio</label>
+                    </div>
                 </div>
             </div>
         </div>
@@ -1189,7 +1191,6 @@ echo $this->form(
                                     'type'    => 'radio',
                                     'name'    => 'gridRadios',
                                     'options' => [
-                                        'column'        => 'sm-10',
                                         'value_options' => [
                                             [
                                                 'label'      => 'First radio',
@@ -2010,17 +2011,19 @@ echo $this->form(
         <div class="row">
             <legend class="col-form-label col-sm-2 pt-0">Radios</legend>
             <div class="col-sm-10">
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios1" value="option1"></input>
-                    <label class="form-check-label" for="gridRadios1">First radio</label>
-                </div>
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios2" value="option2"></input>
-                    <label class="form-check-label" for="gridRadios2">Second radio</label>
-                </div>
-                <div class="form-check">
-                    <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios3" value="option3" disabled="disabled"></input>
-                    <label class="form-check-label" for="gridRadios3">Third disabled radio</label>
+                <div class="form-group">
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios1" value="option1"></input>
+                        <label class="form-check-label" for="gridRadios1">First radio</label>
+                    </div>
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios2" value="option2"></input>
+                        <label class="form-check-label" for="gridRadios2">Second radio</label>
+                    </div>
+                    <div class="form-check">
+                        <input type="radio" name="fieldset[gridRadios]" class="form-check-input" id="gridRadios3" value="option3" disabled="disabled"></input>
+                        <label class="form-check-label" for="gridRadios3">Third disabled radio</label>
+                    </div>
                 </div>
             </div>
         </div>
@@ -2107,7 +2110,6 @@ echo $this->form(
                                     'type'    => 'radio',
                                     'name'    => 'gridRadios',
                                     'options' => [
-                                        'column'        => 'sm-10',
                                         'value_options' => [
                                             [
                                                 'label'      => 'First radio',
@@ -3137,6 +3139,7 @@ echo $this->formRow(
             'name'    => 'customRadio',
             'type'    => 'radio',
             'options' => [
+                'form_group'    => false,
                 'custom'        => true,
                 'value_options' => [
                     [
@@ -3191,6 +3194,7 @@ echo $this->formRow(
             'type'    => 'radio',
             'options' => [
                 'layout'        => \TwbsHelper\Form\View\Helper\Form::LAYOUT_INLINE,
+                'form_group'    => false,
                 'custom'        => true,
                 'value_options' => [
                     [
@@ -3263,6 +3267,7 @@ echo $this->formRow(
             'name'       => 'radioDisabled',
             'type'       => 'radio',
             'options'    => [
+                'form_group'    => false,
                 'custom'        => true,
                 'value_options' => [
                     [


### PR DESCRIPTION
This is a backport of a few of the fixes from #295 to fix #324 in the 4.x series of twbs-helper-module.

A few remarks on these changes:
 - MultiCheckboxes (this includes radio elements which inherit from them) should always have their label prepended. The reasoning behind that is that "label" for this elements does not refer to the actual `<label>` of the checkbox/radio element, but the overall form label, which is a label the the group of checkbox/radio elements alltogether.
 - As such, MultiCheckboxes always need to be wrapped in a `<div class="form-group">`, as otherwise Boostrap cannot render the label correctly. Once again, label here is the label of the group of elements alltogether.
 - Not having MultiCheckboxes wrapped in a `<div class="form-group">` requires setting the option `"form_group" => false`, as it is the case for all other elements as well.
 - I had to update a few test cases to reflect this behaviour correctly.

