### PR TITLE
Avoid deprecation warning as long as we need to support older versions

### DIFF
--- a/src/TwbsHelper/View/HtmlAttributesSet.php
+++ b/src/TwbsHelper/View/HtmlAttributesSet.php
@@ -40,6 +40,7 @@ class HtmlAttributesSet extends \TwbsHelper\View\OriginalHtmlAttributesSet
         $this->cleanAttributes();
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         if (!$this->offsetExists($key) && isset(static::$attributeWithSet[$key])) {

--- a/src/TwbsHelper/View/HtmlClassAttributeSet.php
+++ b/src/TwbsHelper/View/HtmlClassAttributeSet.php
@@ -66,7 +66,7 @@ class HtmlClassAttributeSet extends \ArrayObject
     {
         $classes = $this->getArrayCopy();
 
-        $classes = array_unique(array_filter(array_map('trim', $classes)));
+        $classes = array_unique(array_filter(array_map('trim', array_filter($classes))));
         sort($classes);
 
         $this->exchangeArray($classes);


### PR DESCRIPTION
Avoid deprecation warning:

```
Deprecated: Return type of TwbsHelper\View\HtmlAttributesSet::offsetGet($key) should either be compatible with ArrayObject::offsetGet(mixed $key): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/neilime/twbs-helper-module/src/TwbsHelper/View/HtmlAttributesSet.php on line 47
```

See 
https://php.watch/versions/8.1/ReturnTypeWillChange