### PR TITLE
avoid double escaped entities in labels

### DIFF
--- a/src/TwbsHelper/Form/View/Helper/FormLabel.php
+++ b/src/TwbsHelper/Form/View/Helper/FormLabel.php
@@ -39,8 +39,6 @@ class FormLabel extends \Laminas\Form\View\Helper\FormLabel
             return $labelContent;
         }
 
-
-
         $labelAttributes = $this->prepareLabelAttributes($element);
         $markup = parent::__invoke($element, $labelContent, $position);
 
@@ -71,7 +69,7 @@ class FormLabel extends \Laminas\Form\View\Helper\FormLabel
                 'div',
                 $labelAttributes,
                 $label,
-                !$element->getLabelOption('disable_html_escape')
+                false
             );
         }
 

--- a/tests/TestSuite/TwbsHelper/Form/View/Helper/FormLabelTest.php
+++ b/tests/TestSuite/TwbsHelper/Form/View/Helper/FormLabelTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace TestSuite\TwbsHelper\Form\View\Helper;
+
+class FormLabelTest extends \TestSuite\TwbsHelper\AbstractViewHelperTestCase
+{
+    /**
+     * @var \TwbsHelper\Form\View\Helper\FormLabel
+     */
+    protected $helper = 'formLabel';
+
+    /**
+     * @dataProvider dataProviderRenderLabels
+     */
+    public function testRenderWithLabel($element, string $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            $this->helper->__invoke($element)
+        );
+    }
+
+    public function dataProviderRenderLabels(): array
+    {
+        return [
+            [
+                new \Laminas\Form\Element\Text(
+                    'test_one',
+                    [
+                        'label' => 'Without special chars',
+                    ]
+                ),
+                '<label class="form-label" for="test_one">Without special chars</label>'
+            ],
+            [
+                new \Laminas\Form\Element\Text(
+                    'test_one',
+                    [
+                        'label' => 'With special chars < > &',
+                    ]
+                ),
+                '<label class="form-label" for="test_one">With special chars &lt; &gt; &amp;</label>'
+            ],
+            [
+                new \Laminas\Form\Element\Text(
+                    'test_one',
+                    [
+                        'label' => 'With special chars &lt; &gt; &amp;',
+                    ]
+                ),
+                '<label class="form-label" for="test_one">With special chars &amp;lt; &amp;gt; &amp;amp;</label>'
+            ],
+            [
+                new \Laminas\Form\Element\Text(
+                    'test_one',
+                    [
+                        'label' => 'With a quote\'',
+                    ]
+                ),
+                '<label class="form-label" for="test_one">With a quote&#039;</label>'
+            ],
+            [
+                new \Laminas\Form\Element\MultiCheckbox(
+                    'test_one',
+                    [
+                        'label' => 'Without special chars',
+                    ]
+                ),
+                '<div class="form-label">
+    Without special chars
+</div>'
+            ],
+            [
+                new \Laminas\Form\Element\MultiCheckbox(
+                    'test_one',
+                    [
+                        'label' => 'With special chars < > &',
+                    ]
+                ),
+                '<div class="form-label">
+    With special chars &lt; &gt; &amp;
+</div>'
+            ],
+            [
+                new \Laminas\Form\Element\MultiCheckbox(
+                    'test_one',
+                    [
+                        'label' => 'With special chars &lt; &gt; &amp;',
+                    ]
+                ),
+                '<div class="form-label">
+    With special chars &amp;lt; &amp;gt; &amp;amp;
+</div>'
+            ],
+            [
+                new \Laminas\Form\Element\MultiCheckbox(
+                    'test_one',
+                    [
+                        'label' => 'With a quote\'',
+                    ]
+                ),
+                '<div class="form-label">
+    With a quote&#039;
+</div>'
+            ],
+            [
+                new \Laminas\Form\Element\Text(
+                    'test_one',
+                    [
+                        'label' => 'Without special chars',
+                        'label_options' => [
+                            'disable_html_escape' => true,
+                        ],
+                    ]
+                ),
+                '<label class="form-label" for="test_one">Without special chars</label>'
+            ],
+            [
+                new \Laminas\Form\Element\Text(
+                    'test_one',
+                    [
+                        'label' => 'With special chars < > &',
+                        'label_options' => [
+                            'disable_html_escape' => true,
+                        ],
+                    ]
+                ),
+                '<label class="form-label" for="test_one">With special chars < > &</label>'
+            ],
+            [
+                new \Laminas\Form\Element\Text(
+                    'test_one',
+                    [
+                        'label' => 'With special chars &lt; &gt; &amp;',
+                        'label_options' => [
+                            'disable_html_escape' => true,
+                        ],
+                    ]
+                ),
+                '<label class="form-label" for="test_one">With special chars &lt; &gt; &amp;</label>'
+            ],
+            [
+                new \Laminas\Form\Element\Text(
+                    'test_one',
+                    [
+                        'label' => 'With a quote\'',
+                        'label_options' => [
+                            'disable_html_escape' => true,
+                        ],
+                    ]
+                ),
+                '<label class="form-label" for="test_one">With a quote\'</label>'
+            ],
+            [
+                new \Laminas\Form\Element\MultiCheckbox(
+                    'test_one',
+                    [
+                        'label' => 'Without special chars',
+                        'label_options' => [
+                            'disable_html_escape' => true,
+                        ],
+                    ]
+                ),
+                '<div class="form-label">
+    Without special chars
+</div>'
+            ],
+            [
+                new \Laminas\Form\Element\MultiCheckbox(
+                    'test_one',
+                    [
+                        'label' => 'With special chars < > &',
+                        'label_options' => [
+                            'disable_html_escape' => true,
+                        ],
+                    ]
+                ),
+                '<div class="form-label">
+    With special chars < > &
+</div>'
+            ],
+            [
+                new \Laminas\Form\Element\MultiCheckbox(
+                    'test_one',
+                    [
+                        'label' => 'With special chars &lt; &gt; &amp;',
+                        'label_options' => [
+                            'disable_html_escape' => true,
+                        ],
+                    ]
+                ),
+                '<div class="form-label">
+    With special chars &lt; &gt; &amp;
+</div>'
+            ],
+            [
+                new \Laminas\Form\Element\MultiCheckbox(
+                    'test_one',
+                    [
+                        'label' => 'With a quote\'',
+                        'label_options' => [
+                            'disable_html_escape' => true,
+                        ],
+                    ]
+                ),
+                '<div class="form-label">
+    With a quote\'
+</div>'
+            ],
+        ];
+    }
+}

--- a/tests/TestSuite/TwbsHelper/Form/View/Helper/FormLabelTest.php
+++ b/tests/TestSuite/TwbsHelper/Form/View/Helper/FormLabelTest.php
@@ -12,7 +12,7 @@ class FormLabelTest extends \TestSuite\TwbsHelper\AbstractViewHelperTestCase
     /**
      * @dataProvider dataProviderRenderLabels
      */
-    public function testRenderWithLabel($element, string $expected)
+    public function testRenderWithLabel(\Laminas\Form\Element $element, string $expected)
     {
         $this->assertEquals(
             $expected,


### PR DESCRIPTION
Labels for multicheckboxes are double escaped. 
Avoid this from happening.